### PR TITLE
Enable Cinema only on specific difficulties, default all, and add support for Miku and Christmas theme

### DIFF
--- a/CinemaInfo.cs
+++ b/CinemaInfo.cs
@@ -1,7 +1,12 @@
 ﻿using CustomAlbums;
 using Ionic.Zip;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Assets.Scripts.Database;
+using MelonLoader;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace Cinema
 {
@@ -12,10 +17,10 @@ namespace Cinema
 
         private string _fileName = null;
         private float _opacity;
-
+        private List<int> _activateDifficulties = new List<int> { 1, 2, 3, 4, 5 };
         public string FilePath
         {
-            get { return _fileName == null ? null : $"{album.BasePath}/{_fileName}".Replace('\\', '/'); }
+            get {  return _fileName == null ? null : $"{album.BasePath}/{_fileName}".Replace('\\', '/'); }
         }
 
         public float Opacity
@@ -25,7 +30,10 @@ namespace Cinema
 
         public bool CinemaEnabled
         {
-            get { return _fileName != null; }
+            get
+            {
+                return _fileName != null && _activateDifficulties.Contains(GlobalDataBase.s_DbBattleStage.selectedDifficulty);
+            }
         }
 
         public CinemaInfo(Album customAlbum)
@@ -37,6 +45,8 @@ namespace Cinema
 
             _fileName = jsonData["file_name"].ToString();
             _opacity = float.Parse(jsonData["opacity"].ToString());
+            if (!jsonData.TryGetValue("difficulties", out var list)) return;
+            _activateDifficulties = list.Values<int>().ToList();
         }
 
         public static JObject LoadFromArchive(string filePath)

--- a/Main.cs
+++ b/Main.cs
@@ -72,7 +72,7 @@ namespace Cinema
 
             // Support for Miku scene and Christmas scene
             var sceneNumber = currentAlbum.Info.scene.Split('_')[1];
-            HideAll($"scene_{sceneNumber}{(!Christmas ? string.Empty : "_christmas")}");
+            HideAll($"scene_{sceneNumber}{(Christmas && sceneNumber == "05" ? "_christmas" : string.Empty)}");
         }
 
         public static void HideAll(string sceneName)
@@ -122,7 +122,7 @@ namespace Cinema
             var sceneSuffix = SceneChangeController.curScene.ToString().Length == 1
                 ? $"0{SceneChangeController.curScene}"
                 : SceneChangeController.curScene.ToString();
-            Main.HideAll($"scene_{sceneSuffix}{(!Main.Christmas ? string.Empty : "_christmas")}");
+            Main.HideAll($"scene_{sceneSuffix}{(Main.Christmas && sceneSuffix == "05" ? "_christmas" : string.Empty)}");
         }
 
         [HarmonyPostfix]
@@ -134,7 +134,7 @@ namespace Cinema
             var sceneSuffix = SceneChangeController.curScene.ToString().Length == 1
                 ? $"0{SceneChangeController.curScene}"
                 : SceneChangeController.curScene.ToString();
-            Main.HideAll($"scene_{sceneSuffix}{(!Main.Christmas ? string.Empty : "_christmas")}");
+            Main.HideAll($"scene_{sceneSuffix}{(Main.Christmas && sceneSuffix == "05" ? "_christmas" : string.Empty)}");
         }
     }
 

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -33,8 +33,8 @@ using MelonLoader;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.3.0")]
-[assembly: AssemblyFileVersion("1.1.3.0")]
-[assembly: MelonInfo(typeof(Cinema.Main), "Cinema", "1.1.3", "AshtonMemer")]
+[assembly: AssemblyVersion("1.1.4.0")]
+[assembly: AssemblyFileVersion("1.1.4.0")]
+[assembly: MelonInfo(typeof(Cinema.Main), "Cinema", "1.1.4", "AshtonMemer")]
 [assembly: MelonGame("PeroPeroGames", "MuseDash")]
 [assembly: MelonColor(System.ConsoleColor.DarkYellow)]


### PR DESCRIPTION
Heard the suggestion from someone about how they'd want to have Cinema enable only for a hidden difficulty, so I thought "why not" and implemented it with an optional property in cinema.json. Also added support for Miku and Christmas theme because why not